### PR TITLE
DEVOPS-844: Update so licence activation timeout can be ignored.

### DIFF
--- a/tasks/xpack/security/elasticsearch-xpack-activation.yml
+++ b/tasks/xpack/security/elasticsearch-xpack-activation.yml
@@ -27,14 +27,15 @@
     body: "{{ es_xpack_license }}"
     return_content: yes
     validate_certs: "{{ es_api_validate_certs }}"
-    timeout: 120 # with x-pack, and after restarting, it can take a while for this to return
+    timeout: 35 # with x-pack, and after restarting, it can take a while for this to return
+    status_code: 200,503 # TODO remove 503 when we have fixed the disk iops issues
   register: license_activated
   no_log: True
   when: "'security' in es_xpack_features"
-  failed_when: >
-    license_activated.status != 200 or
-    license_activated.json.license_status is not defined or
-    license_activated.json.license_status != 'valid'
+#  failed_when: > TODO uncomment this when we have fixed the disk iops issues
+#    license_activated.status != 200 or
+#    license_activated.json.license_status is not defined or
+#    license_activated.json.license_status != 'valid'
 
 - debug:
     msg: "License: {{ license_activated }}"

--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -3,8 +3,12 @@ Description=Elasticsearch-{{es_instance_name}}
 Documentation=http://www.elastic.co
 Wants=network-online.target
 After=network-online.target
+StartLimitInterval=600
+StartLimitBurst=5
 
 [Service]
+Restart=on-failure
+RestartSec=30
 Environment=ES_HOME={{es_home}}
 Environment=CONF_DIR={{conf_dir}}
 Environment=ES_PATH_CONF={{conf_dir}}


### PR DESCRIPTION
This will need to be reverted when disk iops issues fixed.
See the TODO comments